### PR TITLE
Passing down routeLoader signal as prop not working

### DIFF
--- a/apps/testing-app/src/routes/[...lang]/(main)/index.tsx
+++ b/apps/testing-app/src/routes/[...lang]/(main)/index.tsx
@@ -1,9 +1,16 @@
 import { Homepage } from '@qwik-2-test-workspace/homepage';
 import { component$ } from '@qwik.dev/core';
-import { type DocumentHead } from '@qwik.dev/router';
+import { routeLoader$, type DocumentHead } from '@qwik.dev/router';
+
+export const useTestLoader = routeLoader$(async () => {
+	return [{ test: 'test' }];
+});
 
 export default component$(() => {
-	return <Homepage />;
+	const testSignal = useTestLoader();
+	console.log('Initial signal value:', testSignal.value);
+
+	return <Homepage testSignal={testSignal} />;
 });
 
 export const head: DocumentHead = {

--- a/libs/app-specific/testing-app/feature-homepage/src/lib/homepage.tsx
+++ b/libs/app-specific/testing-app/feature-homepage/src/lib/homepage.tsx
@@ -1,8 +1,10 @@
-import { $, component$ } from '@qwik.dev/core';
+import { $, Signal, component$ } from '@qwik.dev/core';
 
 import { Link } from '@qwik.dev/router';
 
-export const Homepage = component$(() => {
+export const Homepage = component$((props: {testSignal:Signal<{test:string}[]>}) => {
+	console.log('Homepage signal value:', props.testSignal.value);
+
 	return (
 		<div class="flex flex-col">
 			<h1 class="text-2xl">Homepage 👋</h1>


### PR DESCRIPTION
Passing routeLoader signal (not a value of signal) to component is not working. When logging the value in component signal.value returns undefined.

![Screenshot 2025-02-25 at 14 27 52](https://github.com/user-attachments/assets/69461fc5-16d5-4879-ad7e-7bdce53ca9ba)
