### PR TITLE
Route loader is executed on wrong route

### DIFF
--- a/apps/testing-app/src/routes/[...lang]/(main)/test/index.tsx
+++ b/apps/testing-app/src/routes/[...lang]/(main)/test/index.tsx
@@ -1,6 +1,13 @@
-import { Link } from '@qwik.dev/router';
+import { Link, routeLoader$ } from '@qwik.dev/router';
+
 import { component$ } from '@qwik.dev/core';
 import { inlineTranslate } from 'qwik-speak';
+
+let k = 1;
+export const useRouteLoader = routeLoader$(() => {
+	console.log('route loader', k);
+	return k++;
+});
 
 export default component$(() => {
 	const t = inlineTranslate();


### PR DESCRIPTION
Route loader is defined in test route but gets executed when going to homepage

Reproduction steps:
1. Go to test route (consle log is: route loader 1)
2. Go to homepage (console log is: route loader 2)